### PR TITLE
07 投稿の検索機能を実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,24 @@
 class ApplicationController < ActionController::Base
+  # 全てのアクション前に@search_formを生成
+  before_action :set_search_posts_form
+
   # フラッシュメッセージのキーを追加
   add_flash_types :success, :info, :warning, :danger
 
   # Sorceryのrequire_loginメソッドで使用されるnot_authenticatedメソッドをオーバーライド
   def not_authenticated
     redirect_to login_path, warning: 'ログインしてください'
+  end
+
+  private
+
+  # 検索様に用いる変数@search_formを生成
+  def set_search_posts_form
+    @search_form = SearchPostsForm.new(search_post_params)
+  end
+
+  # paramsの中の :q が空だった場合{}を返す
+  def search_post_params
+    params.fetch(:q, {}).permit(:body, :comment_body, :username)
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -55,6 +55,11 @@ class PostsController < ApplicationController
     redirect_to posts_path, success: '投稿を削除しました'
   end
 
+  # 検索結果の集合を@postsに代入
+  def search
+    @posts = @search_form.search.includes(:user).page(params[:page])
+  end
+
   private
 
   def post_params

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -2,6 +2,7 @@ class SearchPostsForm
   include ActiveModel::Model # Active Recordの書き方が使える
   include ActiveModel::Attributes # この記述によりデータ型を指定
 
+  attribute :body, :string
   attribute :comment_body, :string
   attribute :username, :string
 

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -1,0 +1,6 @@
+class SearchPostsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :body, :string
+end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -21,4 +21,5 @@ class SearchPostsForm
   def splited_bodies
     # 前後の空白をなくし、文字列の間にある空白ごとに分けて配列にしている
     body.strip.split(/[[:blank:]]+/)
+  end
 end

--- a/app/forms/search_posts_form.rb
+++ b/app/forms/search_posts_form.rb
@@ -1,6 +1,24 @@
 class SearchPostsForm
-  include ActiveModel::Model
-  include ActiveModel::Attributes
+  include ActiveModel::Model # Active Recordの書き方が使える
+  include ActiveModel::Attributes # この記述によりデータ型を指定
 
-  attribute :body, :string
+  attribute :comment_body, :string
+  attribute :username, :string
+
+  def search
+    scope = Post.distinct # Postクラスの重複したインスタンスをなくす処理
+    scope =
+      splited_bodies
+        .map { |splited_body| scope.body_contain(splited_body) }
+        .inject { |result, scp| result.or(scp) } if body.present? # splited_bodiesにて返された配列の内の要素一つ一つを検索対象にしている（injectメソッドはループ処理）
+    scope = scope.comment_body_contain(comment_body) if comment_body.present?
+    scope = scope.username_contain(username) if username.present?
+    scope
+  end
+
+  private
+
+  def splited_bodies
+    # 前後の空白をなくし、文字列の間にある空白ごとに分けて配列にしている
+    body.strip.split(/[[:blank:]]+/)
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -26,8 +26,13 @@ class Post < ApplicationRecord
   validates :body, presence: true, length: { maximum: 1000 }
 
   has_many :comments, dependent: :destroy
+
   # likeモデルと関連付け
   has_many :likes, dependent: :destroy
+
   # likeしたuserを取得できる、like_usersという関連名で利用できる
   has_many :like_users, through: :likes, source: :user
+
+  # 「Postモデルのインスタンス.body_contain」でbodyカラムから文字を検索できるスコープ
+  scope :body_contain, ->(word) { where('posts.body LIKE ?', "%#{word}%") }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -35,4 +35,12 @@ class Post < ApplicationRecord
 
   # 「Postモデルのインスタンス.body_contain」でbodyカラムから文字を検索できるスコープ
   scope :body_contain, ->(word) { where('posts.body LIKE ?', "%#{word}%") }
+
+  # 「Postモデルのインスタンス.comment_body_contain」でpostsテーブルにcommentsテーブルを結合、そのあとcommentsテーブルのbodyカラムから文字を検索できるスコープ
+  scope :comment_body_contain,
+        ->(word) { joins(:comments).where('comments.body LIKE ?', "%#{word}%") }
+
+  # 「Postモデルのインスタンス.username_contain」でpostsテーブルにusersテーブルを結合、そのあとusernameカラムから文字を検索できるスコープ
+  scope :username_contain,
+        ->(word) { joins(:user).where('username LIKE ?', "%#{word}%") }
 end

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -1,0 +1,5 @@
+/ @search_form（SearchPostsFormクラスのインスタンス）を指定、アクションはposts#search
+/ scope: :q によってパラメータが paramas[:q][:body] になる
+= form_with model: search_form, url: search_posts_path, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', method: :get, local: true do |f|
+  = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/_search_form.html.slim
+++ b/app/views/posts/_search_form.html.slim
@@ -2,4 +2,6 @@
 / scope: :q によってパラメータが paramas[:q][:body] になる
 = form_with model: search_form, url: search_posts_path, scope: :q, class: 'form-inline my-2 my-lg-0 mr-auto', method: :get, local: true do |f|
   = f.search_field :body, class: 'form-control mr-sm-2', placeholder: '本文'
+  = f.search_field :comment_body, class: 'form-control mr-sm-2', placeholder: 'コメント'
+  = f.search_field :username, class: 'form-control mr-sm-2', placeholder: 'ユーザー名'
   = f.submit 'Search', class: 'btn btn-outline-success my-2 my-sm-0'

--- a/app/views/posts/search.html.slim
+++ b/app/views/posts/search.html.slim
@@ -1,0 +1,8 @@
+/ post#searchアクション後のビュー
+.container
+  .row
+    .col-md-8.col-12.offset-md-2
+      h2.text-center
+        | 検索結果: #{@posts.total_count}件
+      = render @posts
+      = paginate @posts

--- a/app/views/shared/_before_login_header.html.slim
+++ b/app/views/shared/_before_login_header.html.slim
@@ -5,9 +5,8 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarTogglerDemo02.collapse.navbar-collapse
-    form.form-inline.my-2.my-lg-0.mr-auto
-      input.form-control.mr-sm-2 placeholder="Search" type="search" /
-      button.btn.btn-outline-success.my-2.my-sm-0 type="submit"  Search
+    / app/views/posts/_search_form.html.slimのパーシャルを利用
+    = render 'posts/search_form', search_form: @search_form
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item
         = link_to 'ポスト一覧', 'posts_path', class: 'nav-link'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,9 +3,8 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
   button.navbar-toggler aria-controls="navbarTogglerDemo02" aria-expanded="false" aria-label=("Toggle navigation") data-target="#navbarTogglerDemo02" data-toggle="collapse" type="button"
     span.navbar-toggler-icon
   #navbarTogglerDemo02.collapse.navbar-collapse
-    form.form-inline.my-2.my-lg-0.mr-auto
-      input.form-control.mr-sm-2 placeholder="Search" type="search" /
-      button.btn.btn-outline-success.my-2.my-sm-0 type="submit"  Search
+    / app/views/posts/_search_form.html.slimのパーシャルを利用
+    = render 'posts/search_form', search_form: @search_form
     ul.navbar-nav.mt-2.mt-lg-0
       li.nav-item
         = link_to new_post_path, class: 'nav-link' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,6 @@ Rails.application.routes.draw do
   end
   resources :likes, only: %i[create destroy]
   resources :relationships, only: %i[create destroy]
+
+  root 'posts#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   # :shallowオプションを指定するとedit・show・update・destroyのアクション（idを必要とするアクション）のエンドポイントとヘルパーメソッドがスッキリする（浅いネスト）
   resources :posts, shallow: true do
+    collection { get :search } # postsコントローラーのsearchアクション、エンドポイントは /posts/search
     resources :comments
   end
   resources :likes, only: %i[create destroy]


### PR DESCRIPTION
以下の機能を実装

- 全ての投稿を検索対象とすること（フィードに対する検索ではない）
- 検索条件としては以下の三つとする
- 本文に検索ワードが含まれている投稿
- こちらに関しては半角スペースでつなげることでor検索ができるようにする。e.g.「rails ruby」
- コメントに検索ワードが含まれている投稿
- 投稿者の名前に検索ワードが含まれている投稿
- ransackなどの検索用のGemは使わず、フォームオブジェクト、ActiveModelを使って実装すること
- 検索時のパスは/posts/searchとすること