### PR TITLE
13 通知の設定を実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,8 +3,8 @@ class CommentsController < ApplicationController
 
   def create
     @comment = current_user.comments.build(comment_params)
-    if @comment.save
-      # コメントされたら以下の処理を実行
+    if @comment.save && @comment.post.user.notification_on_comment?
+      # コメントされ、なおかつ通知をONにしている場合に以下の処理を実行
       UserMailer.with(
         # mialerには以下の引数を渡している
         user_from: current_user,

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,8 +3,8 @@ class LikesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    if current_user.like(@post)
-      # いいねされたら以下の処理を実行
+    if current_user.like(@post) && @post.user.notification_on_like?
+      # いいねされ、なおかつ通知をONにしている場合に以下の処理を実行
       UserMailer.with(
         # mialerには以下の引数を渡している
         user_from: current_user,

--- a/app/controllers/mypage/notification_settings_controller.rb
+++ b/app/controllers/mypage/notification_settings_controller.rb
@@ -1,0 +1,21 @@
+class Mypage::NotificationSettingsController < Mypage::BaseController
+  def edit
+    @user = User.find(current_user.id)
+  end
+
+  def update
+    @user = User.find(current_user.id)
+    if @user.update(notification_settings_params)
+      redirect_to edit_mypage_notification_setting_path, success: '設定を更新しました' # /mypage/notification_setting/editにリダイレクト
+    else
+      flas.now[:danger] = "設定の更新に失敗しました"
+      render :edit
+    end
+  end
+
+  private
+
+  def notification_settings_params # ストロングパラメータ
+    params.require(:user).permit(:notification_on_comment, :notification_on_like, :notification_on_follow)
+  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -2,8 +2,8 @@ class RelationshipsController < ApplicationController
   before_action :require_login, only: %i[create destroy] # アクションを実行する前にログインが必要
   def create
     @user = User.find(params[:followed_id]) # フォローされる対象のユーザを取得
-    if current_user.follow(@user)
-      # フォローされたら以下の処理を実行
+    if current_user.follow(@user) && @user.notification_on_follow?
+      # フォローされ、、なおかつ通知をONにしている場合に以下の処理を実行
       UserMailer.with(
         # mialerには以下の引数を渡している
         user_from: current_user,

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -4,7 +4,7 @@
 #
 #  id           :bigint           not null, primary key
 #  action_type  :integer          not null
-#  read         :boolean          default(FALSE), not null
+#  read         :boolean          default("unread"), not null
 #  subject_type :string(255)
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,14 +2,17 @@
 #
 # Table name: users
 #
-#  id               :bigint           not null, primary key
-#  avatar           :string(255)
-#  crypted_password :string(255)
-#  email            :string(255)      not null
-#  salt             :string(255)
-#  username         :string(255)      not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
+#  id                      :bigint           not null, primary key
+#  avatar                  :string(255)
+#  crypted_password        :string(255)
+#  email                   :string(255)      not null
+#  notification_on_comment :boolean          default(TRUE)
+#  notification_on_follow  :boolean          default(TRUE)
+#  notification_on_like    :boolean          default(TRUE)
+#  salt                    :string(255)
+#  username                :string(255)      not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
 #
 # Indexes
 #

--- a/app/views/mypage/notification_settings/edit.html.slim
+++ b/app/views/mypage/notification_settings/edit.html.slim
@@ -1,0 +1,17 @@
+/ 通知設定更新甩のフォーム
+= form_with model: @user, url: mypage_notification_setting_path, method: :patch, local: true do |f|
+  = render 'shared/error_messages', object: f.object
+    / チェックボックスにチェックを入れると1、外すと0を送る。それぞれのカラムはboolean型なのでそれぞれtrueかfalseになる。
+  .form-group
+    = f.check_box :notification_on_comment
+    = f.label :notification_on_comment
+
+  .form-group
+    = f.check_box :notification_on_like
+    = f.label :notification_on_like
+
+  .form-group
+    = f.check_box :notification_on_follow
+    = f.label :notification_on_follow
+
+  = f.submit class: 'btn btn-primary btn-raised'

--- a/app/views/mypage/shared/_sidebar.html.slim
+++ b/app/views/mypage/shared/_sidebar.html.slim
@@ -8,3 +8,7 @@ nav
       / 通知一覧ページへのリンク
       = link_to '通知一覧', mypage_activities_path
       hr
+    li
+      / 通知設定ページヘのリンク
+      = link_to '通知設定', edit_mypage_notification_setting_path
+      hr

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,9 @@ ja:
         password_confirmation: 'パスワード確認'
         username: 'ユーザー名'
         avatar: 'アバター'
+        notification_on_comment: 'コメント時の通知メール'
+        notification_on_like: 'いいね時の通知メール'
+        notification_on_follow: 'フォロー時の通知メール'
       post:
         images: '画像'
         body: '本文'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   namespace :mypage do
     resource :account, only: %i[edit update]
     resources :activities, only: %i[index]
+    resource :notification_setting, only: %i[edit update]
   end
 
   root 'posts#index'

--- a/db/migrate/20220206034022_add_notification_flags_to_users.rb
+++ b/db/migrate/20220206034022_add_notification_flags_to_users.rb
@@ -1,0 +1,7 @@
+class AddNotificationFlagsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :notification_on_comment, :boolean, default: true
+    add_column :users, :notification_on_like, :boolean, default: true
+    add_column :users, :notification_on_follow, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_04_085548) do
+ActiveRecord::Schema.define(version: 2022_02_06_034022) do
 
   create_table "activities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "subject_type"
@@ -71,6 +71,9 @@ ActiveRecord::Schema.define(version: 2022_02_04_085548) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.boolean "notification_on_comment", default: true
+    t.boolean "notification_on_like", default: true
+    t.boolean "notification_on_follow", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
以下の条件で通知設定機能を実装

- 通知をするかしないかをユーザーが設定できる
- マイページに通知設定というメニューを追加
- コメント時の通知メール, いいね時の通知メール, フォロー時の通知メールのオンオフを切り替えられる